### PR TITLE
Add model and vectorizer environment variable support

### DIFF
--- a/model_service.py
+++ b/model_service.py
@@ -6,10 +6,9 @@ import os
 
 from libml.text_preprocessing import  preprocess_input
 
+MODEL_URL = os.getenv("MODEL_URL", "https://github.com/remla25-team12/model-training/releases/download/v0.1.0/Classifier_Sentiment_Model.joblib")
+VEC_URL = os.getenv("VEC_URL", "https://github.com/remla25-team12/model-training/releases/download/v0.1.0/c1_BoW_Sentiment_Model.pkl")
 
-# MODEL_URL = os.getenv("MODEL_URL", "http://localhost:5000")
-MODEL_URL = "https://github.com/remla25-team12/model-training/releases/download/v0.1.0/Classifier_Sentiment_Model.joblib"
-VEC_URL = "https://github.com/remla25-team12/model-training/releases/download/v0.1.0/c1_BoW_Sentiment_Model.pkl"
 app = Flask(__name__)
 model = None
 


### PR DESCRIPTION
Small change that adds support for environment variables included in docker-compose.yaml. If for some reason these are not set, it falls back to downloading v0.1.0 of the model and vectorizer.